### PR TITLE
Attempting all packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 products/
 downloads/
 build/
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ deploy:
   skip_cleanup: true
   on:
     repo: ianshmean/x265Builder
-    branch: release
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: julia
 os:
-  - linux
+- linux
 julia:
-  - 0.6
+- 1.0
 notifications:
   email: false
 git:
@@ -10,18 +10,26 @@ git:
 cache:
   timeout: 1000
   directories:
-    - downloads
+  - downloads
+  - shards
 env:
   global:
-    - BINARYBUILDER_DOWNLOADS_CACHE=downloads
-    - BINARYBUILDER_AUTOMATIC_APPLE=false
+  - BINARYBUILDER_DOWNLOADS_CACHE=downloads
+  - BINARYBUILDER_SHARDS_DIR=shards
+  - BINARYBUILDER_AUTOMATIC_APPLE=true
+  - BINARYBUILDER_USE_CCACHE=true
 sudo: required
-
-# Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryProvider.jl")'
-  - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryBuilder.jl"); Pkg.build()'
-
+- julia -e 'using Pkg; pkg"add BinaryProvider"; pkg"add BinaryBuilder#master"; Pkg.build()'
 script:
-  - julia build_tarballs.jl
-
+- julia build_tarballs.jl
+deploy:
+  provider: releases
+  api-key:
+    secure: rHU6H/5Yq2iFXtGsucgkFJvIyMwnvGvQEdEGqNCYRP8SSct8AOXl4dSQkCpvb1VLkYKV0X0lM7HHHXu/PSTKfbx36KpqUeeSvjdFceFiiBWIT0iQW8s6AQXjPDtAiIraFIso1mSkyzlFppSWAolHZI2FVQia1mPHLqRfsw5Tsd5IRwZY/kwOkPPaEAGqpUmshRV83RKZcr9G3nOcGRppx9KH/v1+yYJgWn3zKfqElydiPQ0G27l+WCR3p27KI8sc2pBNo206kgVo9A08cA74HEcChrpTePpQr45VHHDK/2wBNVv7DFZMIivafwsZwjFvh/N/3aXaZSsmPAX64wFsPTU/2EwfiNToq+kIS9QdsvSatcI9tFveNpN21ltxSpi0FOqP4W8PU3IwkD/bP4cdIGnAmdLb0wt+bmeP8YBuDKDcrxgqJA8yj7v7fHZgDkYJbZoRTROlXMnyqowJ7Fuu6FKQoRTqxQmbA9t9pWHSU3lDB3lI98Zmdu+GoNbXve/cNbOcya2YADI2OcDenMSVeazNQ7+HOvfEwDxFqAfcU8MvRMezwWmgpZnz2yw04EgzYVZlney3T1sZhL6H2waKOHEup0CJJCs6HksXNBTTwx1IsFJR5TZZ9sKRr9tIxQo1bqxodLMI031ShftHeJHOzCaA1isbW4HoB/s6TGWTLX4=
+  file_glob: true
+  file: products/*
+  skip_cleanup: true
+  on:
+    repo: ianshmean/x265Builder
+    branch: release

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -8,7 +8,7 @@ version = v"3.0"
 # Collection of sources required to build x265Builder
 sources = [
     "http://ftp.videolan.org/pub/videolan/x265/x265_3.0.tar.gz" =>
-    "6e59f9afc0c2b87a46f98e33b5159d56ffb3558a49d8e3d79cb7fdc6b7aaa863",
+    "c5b9fc260cabbc4a81561a448f4ce9cad7218272b4011feabc3a6b751b2f0662",
 
 ]
 

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -37,14 +37,14 @@ platforms = [
     Linux(:i686, :glibc),
     Linux(:x86_64, :glibc),
     #Linux(:aarch64, :glibc),
-    Linux(:armv7l, :glibc),
+    #Linux(:armv7l, :glibc),
     Linux(:powerpc64le, :glibc),
 
     # musl
     Linux(:i686, :musl),
     Linux(:x86_64, :musl),
     #Linux(:aarch64, :musl),
-    Linux(:armv7l, :musl),
+    #Linux(:armv7l, :musl),
 
     # The BSD's
     FreeBSD(:x86_64),

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -17,9 +17,10 @@ script = raw"""
 cd $WORKSPACE/srcdir
 cd x265_3.0/
 apk add nasm
-nasm --version
+export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig"
+export ENABLE_PIC=1
 mkdir bld && cd bld
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain  ../source
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DENABLE_PIC=ON  ../source
 make -j${nproc}
 make install
 rm -vf $prefix/lib/libx265.a
@@ -28,28 +29,7 @@ rm -vf $prefix/lib/libx265.a
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    # Windows
-    Windows(:i686),
-    Windows(:x86_64),
-
-    # linux
-    Linux(:i686, :glibc),
-    Linux(:x86_64, :glibc),
-    #Linux(:aarch64, :glibc),
-    #Linux(:armv7l, :glibc),
-    Linux(:powerpc64le, :glibc),
-
-    # musl
-    Linux(:i686, :musl),
-    Linux(:x86_64, :musl),
-    #Linux(:aarch64, :musl),
-    #Linux(:armv7l, :musl),
-
-    # The BSD's
-    FreeBSD(:x86_64),
-    MacOS(:x86_64),
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -47,8 +47,8 @@ platforms = [
     Linux(:armv7l, :musl),
 
     # The BSD's
-    #FreeBSD(:x86_64),
-    #MacOS(:x86_64),
+    FreeBSD(:x86_64),
+    MacOS(:x86_64),
 ]
 
 # The products that we will ensure are always built

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -3,11 +3,11 @@
 using BinaryBuilder
 
 name = "x265Builder"
-version = v"2.8"
+version = v"3.0"
 
 # Collection of sources required to build x265Builder
 sources = [
-    "https://bitbucket.org/multicoreware/x265/downloads/x265_2.8.tar.gz" =>
+    "http://ftp.videolan.org/pub/videolan/x265/x265_3.0.tar.gz" =>
     "6e59f9afc0c2b87a46f98e33b5159d56ffb3558a49d8e3d79cb7fdc6b7aaa863",
 
 ]
@@ -15,7 +15,8 @@ sources = [
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-cd x265_2.8/
+cd x265_3.0/
+apk add nasm
 mkdir bld && cd bld
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain ../source
 make -j${nproc}
@@ -26,18 +27,32 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
+    # Windows
+    Windows(:i686),
+    Windows(:x86_64),
+
+    # linux
     Linux(:i686, :glibc),
     Linux(:x86_64, :glibc),
+    Linux(:aarch64, :glibc),
+    Linux(:armv7l, :glibc),
+    Linux(:powerpc64le, :glibc),
+
+    # musl
     Linux(:i686, :musl),
     Linux(:x86_64, :musl),
+    Linux(:aarch64, :musl),
+    Linux(:armv7l, :musl),
+
+    # The BSD's
+    FreeBSD(:x86_64),
     MacOS(:x86_64),
-    FreeBSD(:x86_64)
 ]
 
 # The products that we will ensure are always built
 products(prefix) = [
     LibraryProduct(prefix, "libx265", :libx265),
-    ExecutableProduct(prefix, "", :x265)
+    ExecutableProduct(prefix, "x265", :x265)
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -17,10 +17,12 @@ script = raw"""
 cd $WORKSPACE/srcdir
 cd x265_3.0/
 apk add nasm
+nasm --version
 mkdir bld && cd bld
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain ../source
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain  ../source
 make -j${nproc}
 make install
+rm -vf $prefix/lib/libx265.a
 
 """
 
@@ -34,19 +36,19 @@ platforms = [
     # linux
     Linux(:i686, :glibc),
     Linux(:x86_64, :glibc),
-    Linux(:aarch64, :glibc),
+    #Linux(:aarch64, :glibc),
     Linux(:armv7l, :glibc),
     Linux(:powerpc64le, :glibc),
 
     # musl
     Linux(:i686, :musl),
     Linux(:x86_64, :musl),
-    Linux(:aarch64, :musl),
+    #Linux(:aarch64, :musl),
     Linux(:armv7l, :musl),
 
     # The BSD's
-    FreeBSD(:x86_64),
-    MacOS(:x86_64),
+    #FreeBSD(:x86_64),
+    #MacOS(:x86_64),
 ]
 
 # The products that we will ensure are always built


### PR DESCRIPTION
This is hitting the 50 min travis build limit

For ARM, following needs to be implemented:
> We also support cross-compilation for ARM targets from linux platforms on x86 targets by using the g++ arm cross-compiler. This has been tested on Ubuntu linux 14.04 running on an x86 CPU. On other distributions, package names and names of cross compilation tools may differ. This is an experimental feature, and has undergone very limited testing.

```
$ sudo apt-get install mercurial cmake cmake-curses-gui build-essential gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
$ hg clone https://bitbucket.org/multicoreware/x265
$ cd x265/build/arm-linux
$ ./make-Makefiles.bash
$ make
```
https://bitbucket.org/multicoreware/x265/wiki/Home